### PR TITLE
chore: Bump osfexport to 1.0.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,4 +6,4 @@ pillow==11.3.0
 pytz==2025.2
 letter==0.5
 reportlab==4.4.2
-osfexport==0.2.2
+osfexport==1.0.0


### PR DESCRIPTION
Use final release! https://pypi.org/project/osfexport/#description